### PR TITLE
feat: 주식 삭제 API 구현 및 User 모델 추가

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -27,7 +27,9 @@ app.get('/', (req, res) => {
 // 모든 주식 정보 가져오기 API 엔드포인트
 app.get('/stocks', async (req, res) => {
   try {
-    const stocks = await db.stocks.findAll();
+    console.log('Available models:', Object.keys(db));
+    console.log('db.stock:', db.stock);
+    const stocks = await db.stock.findAll();
     res.status(200).json(stocks);
   } catch (error) {
     console.error('Error fetching stocks:', error);
@@ -68,7 +70,7 @@ app.post('/stock/add', async (req, res) => {
 
           if (fetchedStockName) {
             // stocks 테이블에 저장
-            const [stock, created] = await db.stocks.findOrCreate({
+            const [stock, created] = await db.stock.findOrCreate({
               where: { symbol: symbol },
               defaults: {
                 symbol: symbol,
@@ -135,6 +137,39 @@ app.get('/stock/:symbol/foreign', async (req, res) => {
   } catch (error) {
     console.error('Error fetching market data:', error);
     res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
+// 주식 삭제 API 엔드포인트
+app.delete('/stock/:symbol', async (req, res) => {
+  console.log('=== 주식 삭제 요청 시작 ===');
+  const { symbol } = req.params;
+  console.log('삭제할 종목 코드:', symbol);
+
+  try {
+    const deletedCount = await db.stock.destroy({
+      where: { symbol: symbol }
+    });
+
+    if (deletedCount > 0) {
+      console.log('주식 삭제 성공:', symbol);
+      res.status(200).json({ 
+        message: '주식이 성공적으로 삭제되었습니다.',
+        symbol: symbol 
+      });
+    } else {
+      console.log('삭제할 주식을 찾을 수 없음:', symbol);
+      res.status(404).json({ 
+        message: '삭제할 주식을 찾을 수 없습니다.',
+        symbol: symbol 
+      });
+    }
+  } catch (error) {
+    console.error('주식 삭제 오류:', error);
+    res.status(500).json({ 
+      message: '주식 삭제 중 오류가 발생했습니다.',
+      error: error.message 
+    });
   }
 });
 

--- a/api-server/models/user.js
+++ b/api-server/models/user.js
@@ -1,7 +1,7 @@
 'use strict';
 const { Model } = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
-  class Stock extends Model {
+  class User extends Model {
     /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
@@ -9,21 +9,30 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      // Stock belongs to User
-      Stock.belongsTo(models.user, {
+      // User has many Stocks
+      User.hasMany(models.stock, {
         foreignKey: 'userId',
-        as: 'user'
+        as: 'stocks'
       });
     }
   }
-  Stock.init({
-    symbol: DataTypes.STRING,
-    name: DataTypes.STRING,
-    userId: DataTypes.INTEGER
+  User.init({
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        isEmail: true
+      }
+    },
+    nickname: {
+      type: DataTypes.STRING,
+      allowNull: true
+    }
   }, {
     sequelize,
-    modelName: 'stock',
-    tableName: 'Stocks',
+    modelName: 'user',
+    tableName: 'Users',
   });
-  return Stock;
+  return User;
 }; 


### PR DESCRIPTION
### 주식 삭제 API 구현
- `DELETE /stock/:symbol` 엔드포인트 추가
- 데이터베이스에서 해당 주식 완전 삭제
- 적절한 응답 메시지 및 상태 코드 반환

### Flutter 앱 주식 삭제 기능
- 주식관리 페이지에 쓰레기통 아이콘 추가
- 삭제 확인 다이얼로그 구현
- 삭제 후 주식 목록 자동 새로고침
- 성공/실패 메시지 표시

### User 모델 생성
- `api-server/models/user.js` 모델 파일 추가
- Users 테이블과 연동
- Stock 모델과 1:N 관계 설정
- 향후 로그인 시스템 구현 준비

## 🔧 기술적 개선사항

### API 서버 모델명 수정
- `db.stock` 모델명으로 통일
- Sequelize 모델 로딩 문제 해결
- 데이터베이스 테이블명 `Stocks`와 정확히 매핑

### 관계 설정
- User ↔ Stock 1:N 관계 구현
- `User.hasMany(Stock)` 및 `Stock.belongsTo(User)`
- 사용자별 주식 관리 가능

## 🧪 테스트 완료
- ✅ 주식 추가 API 테스트
- ✅ 주식 삭제 API 테스트  
- ✅ 중복 추가 방지 테스트
- ✅ User 모델 관계 테스트
- ✅ Flutter 앱 연동 테스트