### PR TITLE
빌드 파일 제거 및 .gitignore 강화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,16 @@ fiflow_app/.pub/
 fiflow_app/build/
 fiflow_app/ios/Pods/
 
+# Build files and reports
+**/build/
+**/build/reports/
+**/build/reports/problems/
+**/build/reports/problems/problems-report.html
+**/android/build/
+**/android/build/reports/
+**/android/build/reports/problems/
+**/android/build/reports/problems/problems-report.html
+
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
수행한 작업:
1. 빌드 파일 제거
✅ Git 캐시에서 제거: git rm -r --cached
✅ HTML 빌드 리포트 제거: problems-report.html 파일들
✅ Flutter 빌드 폴더 제거: build/ 폴더들
2. .gitignore 강화
✅ 구체적인 패턴 추가: **/build/, **/build/reports/ 등
✅ 앞으로 자동 제외: 빌드 파일들이 자동으로 Git에서 제외됨
✅ 다양한 빌드 파일 패턴: Android, Flutter 빌드 파일 모두 포함